### PR TITLE
修复歌词跟随，优化切换下一首的逻辑

### DIFF
--- a/lib/common/api/search/bilibili.dart
+++ b/lib/common/api/search/bilibili.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/icon.dart';
 import 'package:listenall/common/api/dio_groups.dart';
 
 import '../../models/music_basic_info.dart';

--- a/lib/common/api/search/netease.dart
+++ b/lib/common/api/search/netease.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/widgets/icon.dart';
 import '../../models/index.dart';
 import '../dio_groups.dart';
 import '../index.dart';

--- a/lib/common/routers/pages.dart
+++ b/lib/common/routers/pages.dart
@@ -12,7 +12,7 @@ class RoutePages {
     ),
     GetPage(
       name: RouteNames.networkSearch,
-      page: () => NetworkSearchPage(),
+      page: () => const NetworkSearchPage(),
       transition: Transition.rightToLeft,
     ),
     GetPage(

--- a/lib/common/services/audio_service.dart
+++ b/lib/common/services/audio_service.dart
@@ -119,7 +119,7 @@ class AudioService extends GetxService {
     await _player.seek(newDuration);
   }
 
-  Future<void> _setSource({bool autoPlay = true}) async {
+  Future<void> _setSource({bool autoPlay = true, bool tryNext = true}) async {
     if (_currentPlayListItemIndex < 0) {
       _currentPlayListItemIndex = 0;
     }
@@ -130,7 +130,10 @@ class AudioService extends GetxService {
     final meida =
         await _playlist[_currentPlayListItemIndex].sources[0].getMedia();
     if (meida == null) {
-      tryNextSource();
+      if (tryNext) {
+        currentPlayListItemIndex = _currentPlayListItemIndex;
+        tryNextSource();
+      }
       return;
     }
     await _player.open(meida, play: autoPlay);
@@ -256,7 +259,7 @@ class AudioService extends GetxService {
       print(_playlist.indexWhere((element) => element.basicInfo == song));
       _currentPlayListItemIndex =
           _playlist.indexWhere((element) => element.basicInfo == song);
-      _setSource();
+      _setSource(tryNext: false);
     }
     return res;
   }

--- a/lib/pages/player/controller.dart
+++ b/lib/pages/player/controller.dart
@@ -96,7 +96,7 @@ class PlayerController extends GetxController {
       playedDurationSubscription =
           audioService.playedDurationStream.listen((event) {
         playedDuration = event;
-        update(['progressIndicator']);
+        update(['progressIndicator', 'lyrics']);
       });
     });
   }


### PR DESCRIPTION
This pull request fixes two issues with song playback and auto switching logic. The first issue addressed is related to the lyrics not following the song when it is played. The second issue fixed is the incorrect logic for automatically switching to the next song. These changes ensure that the lyrics are synchronized with the song and the auto switching logic works correctly.